### PR TITLE
fix(package.json): fix build script on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"build": "del dist && tsc",
+		"build": "del-cli dist && tsc",
 		"prepack": "npm run build",
 		"test": "tsc && xo && nyc ava"
 	},


### PR DESCRIPTION
See [here](https://github.com/sindresorhus/del-cli#usage):

> Since `$ del` is already a builtin command on Windows, you need to use `$ del-cli` there.

I lost about 2 hours because of this, haha :sweat_smile: 

So Windows users will be happy and users of other OSes won't even notice a difference after this PR.